### PR TITLE
feat: add Tailscale MagicDNS to Homepage pod, add Forgejo

### DIFF
--- a/kubernetes/argocd/manifests/homepage/dns-patch.yaml
+++ b/kubernetes/argocd/manifests/homepage/dns-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homepage
+  namespace: homepage
+spec:
+  template:
+    spec:
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 100.100.100.100  # Tailscale MagicDNS
+          - 10.43.0.10       # CoreDNS (cluster services)
+        searches:
+          - homepage.svc.cluster.local
+          - svc.cluster.local
+          - cluster.local
+          - taile67c31.ts.net

--- a/kubernetes/argocd/values/homepage.yaml
+++ b/kubernetes/argocd/values/homepage.yaml
@@ -106,7 +106,7 @@ config:
             description: Smart home control
             widget:
               type: homeassistant
-              url: http://10.0.0.99:8123
+              url: http://homeassistant.taile67c31.ts.net:8123
               key: "{{HOMEPAGE_VAR_HA_TOKEN}}"
               custom:
                 - state: weather.forecast_home
@@ -135,6 +135,12 @@ config:
             icon: mdi-robot-outline
             href: "#"
             description: AI Agent (Igris)
+            ping: http://dev-openclaw.taile67c31.ts.net:18789
+        - Forgejo:
+            icon: forgejo
+            href: http://dev-openclaw.taile67c31.ts.net:3000
+            description: Git hosting
+            ping: http://dev-openclaw.taile67c31.ts.net:3000
 
     - GitHub:
         - home.io:


### PR DESCRIPTION
## What

Gives the Homepage pod direct access to the tailnet via MagicDNS, so it can resolve and query any Tailscale-exposed service.

## Changes

### DNS Patch (`manifests/homepage/dns-patch.yaml`)
- Sets `dnsPolicy: None` with custom `dnsConfig`
- Nameservers: `100.100.100.100` (Tailscale MagicDNS) + `10.43.0.10` (CoreDNS)
- Search domains include both `cluster.local` and `taile67c31.ts.net`
- Merges with Helm-managed Deployment via `ServerSideApply=true` (already enabled)

### Homepage Values
- **Home Assistant** — switched back to Tailscale hostname (was hardcoded internal IP)
- **OpenClaw** — re-added ping via tailnet hostname
- **Forgejo** — new card with ping at `dev-openclaw.taile67c31.ts.net:3000`

## Why

Homepage pod couldn't resolve `*.taile67c31.ts.net` hostnames because cluster DNS (CoreDNS) doesn't know about MagicDNS. This caused widget failures for any service outside the cluster.

Instead of a full Tailscale sidecar, this adds Tailscale's MagicDNS resolver (`100.100.100.100`) to the pod's DNS config. Much lighter — no extra containers, no auth keys, just DNS resolution.